### PR TITLE
Add separate model listing endpoints

### DIFF
--- a/app/routers/models.py
+++ b/app/routers/models.py
@@ -10,7 +10,8 @@ from typing import List, Dict
 
 from app.routers.auth import get_current_username
 from app.utils.ollama import (
-    list_remote_models,
+    list_remote_base_models,
+    list_model_variants,
     list_installed_models,
     install_model,
     remove_model,
@@ -22,9 +23,45 @@ router = APIRouter()
 async def get_models(username: str = Depends(get_current_username)) -> Dict[str, List[str]]:
     """Возвращает списки доступных и локально установленных моделей"""
     try:
-        available = list_remote_models()
+        available = list_remote_base_models()
         installed = list_installed_models()
         return {"available": available, "installed": installed}
+    except RuntimeError as e:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=str(e)
+        )
+
+
+@router.get("/available", response_model=List[str])
+async def available_models(username: str = Depends(get_current_username)) -> List[str]:
+    """Список моделей, доступных для установки (без вариантов)."""
+    try:
+        return list_remote_base_models()
+    except RuntimeError as e:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=str(e)
+        )
+
+
+@router.get("/installed", response_model=List[str])
+async def installed_models(username: str = Depends(get_current_username)) -> List[str]:
+    """Список локально установленных моделей."""
+    try:
+        return list_installed_models()
+    except RuntimeError as e:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=str(e)
+        )
+
+
+@router.get("/{name}/variants", response_model=List[str])
+async def model_variants(name: str, username: str = Depends(get_current_username)) -> List[str]:
+    """Вариации указанной модели с параметрами."""
+    try:
+        return list_model_variants(name)
     except RuntimeError as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,


### PR DESCRIPTION
## Summary
- split remote model discovery helpers into base names and variants
- expose API endpoints for available models, installed models and variants

## Testing
- `python -m py_compile $(git ls-files '*.py')`
